### PR TITLE
Fix /add_event - date to be pushed as moment object

### DIFF
--- a/server.js
+++ b/server.js
@@ -43,7 +43,7 @@ app.get('/', (req, res) => {
 
 app.use(require('body-parser').json());
 app.post('/add_event', (req, res) => {
-  event = {
+  let event = {
     description: req.body.description,
     date: moment(req.body.date)
   };

--- a/server.js
+++ b/server.js
@@ -43,7 +43,11 @@ app.get('/', (req, res) => {
 
 app.use(require('body-parser').json());
 app.post('/add_event', (req, res) => {
-  events.push(req.body);
+  event = {
+    description: req.body.description,
+    date: moment(req.body.date)
+  };
+  events.push(event);
   res.sendStatus(200);
 });
 


### PR DESCRIPTION
Date was pushed as string to events list in /add_event endpoint. As a result, when trying to refresh page after adding an event, the following error appeared in the server log and page was not refreshed:

    [Vue warn]: Error in render: "TypeError: event.date.isSame is not a function"
    found in
    ---> <CalendarDay> at /home/nik/projl/vue-ult-course/vuejs-calendar/src/components/CalendarDay.vue
           <App> at /home/nik/projl/vue-ult-course/vuejs-calendar/src/components/App.vue
             <Root>
    TypeError: event.date.isSame is not a function
        at $store.state.events.filter.event (__vue_ssr_bundle__:30166:72)
    ...

This fix converts the date received from browser to a moment object before pushing to the events list.